### PR TITLE
Create `stats_folder` if not exists

### DIFF
--- a/cleanfid/fid.py
+++ b/cleanfid/fid.py
@@ -282,6 +282,7 @@ Cache a custom dataset statistics file
 def make_custom_stats(name, fdir, num=None, mode="clean", 
                     num_workers=0, batch_size=64, device=torch.device("cuda")):
     stats_folder = os.path.join(os.path.dirname(cleanfid.__file__), "stats")
+    os.makedirs(stats_folder, exist_ok=True)
     split, res = "custom", "na"
     outname = f"{name}_{mode}_{split}_{res}.npz"
     outf = os.path.join(stats_folder, outname)


### PR DESCRIPTION
There is a small bug that a stats directory is not created automatically. This leads to an exception when creating custom dataset statistics. Example: https://colab.research.google.com/drive/13WFqmUYJEgyJ9LEnVtIBFL9b3Crx_t7i?usp=sharing

Relevant comment: https://github.com/GaParmar/clean-fid/issues/9#issuecomment-919837187

  
  
P.S. sorry for such a small PR, but I've encountered this issue a couple of times already (different machines and conda environments), and I always forget to create a stats folder beforehand. And only after waiting for computation for the whole dataset, I receive this error. 
Awesome work and repo after all!