### PR TITLE
fix FileNotFoundError on Windows

### DIFF
--- a/cleanfid/features.py
+++ b/cleanfid/features.py
@@ -2,6 +2,7 @@
 helpers for extracting features from image
 """
 import os
+import platform
 import numpy as np
 import torch
 import torch.nn as nn
@@ -17,7 +18,8 @@ and outputs a feature embedding vector
 """
 def feature_extractor(name="torchscript_inception", device=torch.device("cuda"), resize_inside=False):
     if name == "torchscript_inception":
-        model = InceptionV3W("/tmp", download=True, resize_inside=resize_inside).to(device)
+        path = "./" if platform.system() == "Windows" else "/tmp"
+        model = InceptionV3W(path, download=True, resize_inside=resize_inside).to(device)
         model.eval()
         def model_fn(x): return model(x)
     elif name == "pytorch_inception":


### PR DESCRIPTION
As the "/tmp" directory does not exist on Windows, calling 'compute_fid' or 'make_custom_stats' results in this error:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp\\inception-2015-12-05.pt'
I was able to fix this by simply using the current directory in feature_extractor() if the platform is detected to be 'Windows'

