### PR TITLE
Add code to compute FID/KID between a model and a folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ figures/*
 
 docs/build.md
 temp/**/*.*
+
+# PyCharm
+**/.idea/**/*


### PR DESCRIPTION
This PR adds code to compute FID/KID between a model and a folder. In the previous version, this scenario requires sampling from the model and saving the images. However, saving images usually involves compression, which may cause inconsistency as observed in the paper. 