### PR TITLE
Save custom stats in lowercase to match the loading code

### DIFF
--- a/cleanfid/fid.py
+++ b/cleanfid/fid.py
@@ -324,7 +324,7 @@ def make_custom_stats(name, fdir, num=None, mode="clean",
     stats_folder = os.path.join(os.path.dirname(cleanfid.__file__), "stats")
     os.makedirs(stats_folder, exist_ok=True)
     split, res = "custom", "na"
-    outname = f"{name}_{mode}_{split}_{res}.npz"
+    outname = f"{name}_{mode}_{split}_{res}.npz".lower()
     outf = os.path.join(stats_folder, outname)
     # if the custom stat file already exists
     if os.path.exists(outf):
@@ -343,7 +343,7 @@ def make_custom_stats(name, fdir, num=None, mode="clean",
     print(f"saving custom FID stats to {outf}")
     np.savez_compressed(outf, mu=mu, sigma=sigma)
     # KID stats
-    outf = os.path.join(stats_folder, f"{name}_{mode}_{split}_{res}_kid.npz")
+    outf = os.path.join(stats_folder, f"{name}_{mode}_{split}_{res}_kid.npz".lower())
     print(f"saving custom KID stats to {outf}")
     np.savez_compressed(outf, feats=np_feats)
 


### PR DESCRIPTION
The [code](https://github.com/GaParmar/clean-fid/blob/3cdadba22235768c99c587b982c558b2814fb0db/cleanfid/features.py#L56) loading pre-computed stats assumes lower-case namings.

Change code saving the stats to make it compatible to this assumption.