### PR TITLE
fix tranform typo

### DIFF
--- a/cleanfid/utils.py
+++ b/cleanfid/utils.py
@@ -21,7 +21,7 @@ class ResizeDataset(torch.utils.data.Dataset):
         self.transforms = torchvision.transforms.ToTensor()
         self.size = size
         self.fn_resize = build_resizer(mode)
-        self.custom_image_tranform = lambda x: x
+        self.custom_image_transform = lambda x: x
         self._zipfile = None
 
     def _get_zipfile(self):
@@ -45,7 +45,7 @@ class ResizeDataset(torch.utils.data.Dataset):
             img_np = np.array(img_pil)
 
         # apply a custom image transform before resizing the image to 299x299
-        img_np = self.custom_image_tranform(img_np)
+        img_np = self.custom_image_transform(img_np)
         # fn_resize expects a np array and returns a np array
         img_resized = self.fn_resize(img_np)
 


### PR DESCRIPTION
Hi,

this is just a fix for a minor typo in fid.py and utils.py where an argument was called   `custom_image_tranform` while you expected to call it `custom_image_transform`  I suppose.

This PR just applied

```
cd cleanfid
sed -i 's/custom_image_tranform/custom_image_transform/g' *.py
```